### PR TITLE
Do not ask Twilio to record in initial make_call call (tests green)

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -16,7 +16,6 @@ class EbtBalanceSmsApp < Sinatra::Base
         to: "+18773289677",
         send_digits: "ww1ww#{@debit_number.to_s}",
         from: ENV['TWILIO_NUMBER'],
-        record: "true",
         method: "GET"
       )
       text_message = @twilio_service.send_text(

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -18,7 +18,6 @@ describe EbtBalanceSmsApp do
           to: '+18773289677',
           send_digits: "ww1ww#{ebt_number}",
           from: 'loltwilionumber',
-          record: 'true',
           method: 'GET'
         )
       end


### PR DESCRIPTION
This PR removes an extraneous use of Twilio's RECORD feature; since we're already transcribing (which yields a recording) we don't need to tell it to record here also.

Tested on staging and confirmed in Twilio logs that we've moved from 2 recordings per text to 1 recording:

![screen shot 2014-08-07 at 1 56 22 pm](https://cloud.githubusercontent.com/assets/994938/3849021/6e569bd0-1e75-11e4-91f9-9896cf644e39.png)
