### PR TITLE
Replace env Twilio phone number with use of inbound request parameter,

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,2 @@
-TWILIO_NUMBER=loltwilionumber
 TWILIO_SID=mytwiliosid
 TWILIO_AUTH=mytwilioauth

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A text message interface for EBT balance
 
 Set the following environment variables:
 
-- TWILIO_NUMBER
 - TWILIO_SID
 - TWILIO_AUTH
 

--- a/app.rb
+++ b/app.rb
@@ -8,25 +8,26 @@ class EbtBalanceSmsApp < Sinatra::Base
   post '/' do
     @twilio_service = TwilioService.new(Twilio::REST::Client.new(ENV['TWILIO_SID'], ENV['TWILIO_AUTH']))
     @texter_phone_number = params["From"]
+    @inbound_twilio_number = params["To"]
     @debit_number = DebitCardNumber.new(params["Body"])
-    @twiml_url = "#{request.env['rack.url_scheme']}://#{request.env['HTTP_HOST']}/get_balance?phone_number=#{@texter_phone_number}"
+    @twiml_url = "#{request.env['rack.url_scheme']}://#{request.env['HTTP_HOST']}/get_balance?phone_number=#{@texter_phone_number}&twilio_phone_number=#{@inbound_twilio_number}"
     if @debit_number.is_valid?
       call = @twilio_service.make_call(
         url: @twiml_url,
         to: "+18773289677",
         send_digits: "ww1ww#{@debit_number.to_s}",
-        from: ENV['TWILIO_NUMBER'],
+        from: @inbound_twilio_number,
         method: "GET"
       )
       text_message = @twilio_service.send_text(
         to: @texter_phone_number,
-        from: ENV['TWILIO_NUMBER'],
+        from: @inbound_twilio_number,
         body: "Thanks! Please wait 1-2 minutes while we check your EBT balance."
       )
     else
       text_message = @twilio_service.send_text(
         to: @texter_phone_number,
-        from: ENV['TWILIO_NUMBER'],
+        from: @inbound_twilio_number,
         body: "Sorry, that EBT number doesn't look right. Please try again."
       )
     end
@@ -34,8 +35,9 @@ class EbtBalanceSmsApp < Sinatra::Base
 
   get '/get_balance' do
     @phone_number = params[:phone_number].strip
+    @twilio_number = params[:twilio_phone_number].strip
     @my_response = Twilio::TwiML::Response.new do |r|
-      r.Record :transcribeCallback => "#{request.env['rack.url_scheme']}://#{request.env['HTTP_HOST']}/#{@phone_number}/send_balance", :maxLength => 18 #:transcribe => true
+      r.Record :transcribeCallback => "#{request.env['rack.url_scheme']}://#{request.env['HTTP_HOST']}/#{@phone_number}/#{@twilio_number}/send_balance", :maxLength => 18 #:transcribe => true
     end
     @my_response.text
   end
@@ -44,12 +46,12 @@ class EbtBalanceSmsApp < Sinatra::Base
     # Twilio posts unused data here; necessary simply to avoid 404 error in logs
   end
 
-  post '/:phone_number/send_balance' do
+  post '/:to_phone_number/:from_phone_number/send_balance' do
     transcription = Transcription.new(params["TranscriptionText"])
     @twilio_service = TwilioService.new(Twilio::REST::Client.new(ENV['TWILIO_SID'], ENV['TWILIO_AUTH']))
     @twilio_service.send_text(
-      to: params[:phone_number].strip,
-      from: ENV['TWILIO_NUMBER'],
+      to: params[:to_phone_number].strip,
+      from: params[:from_phone_number],
       body: "Hi! Your food stamp balance is #{transcription.ebt_amount} and your cash balance is #{transcription.cash_amount}."
     )
   end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -5,19 +5,20 @@ describe EbtBalanceSmsApp do
     context 'with valid EBT number' do
       let(:ebt_number) { "1111222233334444" }
       let(:texter_number) { "+12223334444" }
+      let(:inbound_twilio_number) { "+15556667777" }
       let(:fake_twilio) { double("FakeTwilioService", :make_call => 'made call', :send_text => 'sent text') }
 
       before do
         allow(TwilioService).to receive(:new).and_return(fake_twilio)
-        post '/', { "Body" => ebt_number, "From" => texter_number }
+        post '/', { "Body" => ebt_number, "From" => texter_number, "To" => inbound_twilio_number }
       end
 
       it 'initiates an outbound Twilio call to EBT line with correct details' do
         expect(fake_twilio).to have_received(:make_call).with(
-          url: "http://example.org/get_balance?phone_number=#{texter_number}",
+          url: "http://example.org/get_balance?phone_number=#{texter_number}&twilio_phone_number=#{inbound_twilio_number}",
           to: '+18773289677',
           send_digits: "ww1ww#{ebt_number}",
-          from: 'loltwilionumber',
+          from: inbound_twilio_number,
           method: 'GET'
         )
       end
@@ -25,7 +26,7 @@ describe EbtBalanceSmsApp do
       it 'sends a text to the user telling them wait time' do
         expect(fake_twilio).to have_received(:send_text).with(
           to: texter_number,
-          from: 'loltwilionumber',
+          from: inbound_twilio_number,
           body: "Thanks! Please wait 1-2 minutes while we check your EBT balance."
         )
       end
@@ -38,17 +39,18 @@ describe EbtBalanceSmsApp do
     context 'with INVALID EBT number' do
       let(:invalid_ebt_number) { "111122223333" }
       let(:texter_number) { "+12223334444" }
+      let(:inbound_twilio_number) { "+15556667777" }
       let(:fake_twilio) { double("FakeTwilioService", :make_call => 'made call', :send_text => 'sent text') }
 
       before do
         allow(TwilioService).to receive(:new).and_return(fake_twilio)
-        post '/', { "Body" => invalid_ebt_number, "From" => texter_number }
+        post '/', { "Body" => invalid_ebt_number, "From" => texter_number, "To" => inbound_twilio_number }
       end
 
       it 'sends a text to the user with error message' do
         expect(fake_twilio).to have_received(:send_text).with(
           to: texter_number,
-          from: 'loltwilionumber',
+          from: inbound_twilio_number,
           body: "Sorry, that EBT number doesn't look right. Please try again."
         )
       end
@@ -60,8 +62,11 @@ describe EbtBalanceSmsApp do
   end
 
   describe 'GET /get_balance' do
+    let(:texter_number) { "+12223334444" }
+    let(:inbound_twilio_number) { "+15556667777" }
+
     before do
-      get '/get_balance?phone_number=+12223334444'
+      get "/get_balance?phone_number=#{texter_number}&twilio_phone_number=#{inbound_twilio_number}"
       parsed_response = Nokogiri::XML(last_response.body)
       record_attributes = parsed_response.children.children[0].attributes
       @callback_url = record_attributes["transcribeCallback"].value
@@ -69,7 +74,7 @@ describe EbtBalanceSmsApp do
     end
 
     it 'responds with callback to correct URL (ie, correct phone number)' do
-      expect(@callback_url).to eq("http://example.org/12223334444/send_balance")
+      expect(@callback_url).to eq("http://example.org/12223334444/15556667777/send_balance")
     end
 
     it 'has max recording length set correctly' do
@@ -82,18 +87,19 @@ describe EbtBalanceSmsApp do
   end
 
   describe 'sending the balance to user' do
-    let(:phone_number) { "19998887777" }
+    let(:to_phone_number) { "19998887777" }
+    let(:twilio_number) { "+15556667777" }
     let(:fake_twilio) { double("FakeTwilioService", :send_text => 'sent text') }
 
     before do
       allow(TwilioService).to receive(:new).and_return(fake_twilio)
-      post "/#{phone_number}/send_balance", { "TranscriptionText" => "Your food stamp balance is $123.45 your cash account balance is $0 as a reminder by saving the receipt from your last purchase and your last a cash purchase for Cash Bank Transaction you will always have your current balance at and will also print your balance on the Cash Withdrawal receipt to hear the number of Cash Withdrawal for that a transaction fee (running?) this month press 1 to hear your last 10 transactions report a transaction there file a claim or check the status of a claim press 2 to report your card lost stolen or damaged press 3 for (pin?) replacement press 4 for additional options press 5" }
+      post "/#{to_phone_number}/#{twilio_number}/send_balance", { "TranscriptionText" => "Your food stamp balance is $123.45 your cash account balance is $0 as a reminder by saving the receipt from your last purchase and your last a cash purchase for Cash Bank Transaction you will always have your current balance at and will also print your balance on the Cash Withdrawal receipt to hear the number of Cash Withdrawal for that a transaction fee (running?) this month press 1 to hear your last 10 transactions report a transaction there file a claim or check the status of a claim press 2 to report your card lost stolen or damaged press 3 for (pin?) replacement press 4 for additional options press 5" }
     end
 
     it 'sends the correct amounts to user' do
       expect(fake_twilio).to have_received(:send_text).with(
-        to: phone_number,
-        from: 'loltwilionumber',
+        to: to_phone_number,
+        from: twilio_number,
         body: 'Hi! Your food stamp balance is $123.45 and your cash balance is $0.'
       )
     end


### PR DESCRIPTION
closes #20 
- Has been tested on Staging with a separate phone number (new phone numbers have to be under same Twilio subaccount as the SID and auth token in ENV)
