### PR TITLE
Send helpful error text message if EBT card reported invalid by CA state...

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -48,10 +48,18 @@ class EbtBalanceSmsApp < Sinatra::Base
   post '/:to_phone_number/:from_phone_number/send_balance' do
     transcription = Transcription.new(params["TranscriptionText"])
     twilio_service = TwilioService.new(Twilio::REST::Client.new(ENV['TWILIO_SID'], ENV['TWILIO_AUTH']))
-    twilio_service.send_text(
-      to: params[:to_phone_number].strip,
-      from: params[:from_phone_number],
-      body: "Hi! Your food stamp balance is #{transcription.ebt_amount} and your cash balance is #{transcription.cash_amount}."
-    )
+    if transcription.invalid_ebt_number?
+      twilio_service.send_text(
+        to: params[:to_phone_number].strip,
+        from: params[:from_phone_number],
+        body: "I'm sorry, that card number was not found. Please try again. (Note: this service only works in California right now.)"
+      )
+    else
+      twilio_service.send_text(
+        to: params[:to_phone_number].strip,
+        from: params[:from_phone_number],
+        body: "Hi! Your food stamp balance is #{transcription.ebt_amount} and your cash balance is #{transcription.cash_amount}."
+      )
+    end
   end
 end

--- a/lib/transcription.rb
+++ b/lib/transcription.rb
@@ -3,8 +3,18 @@ class Transcription
 
   def initialize(raw_text)
     @raw_text = raw_text
-    regex_matches = @raw_text.scan(/(\$\S+)/)
-    @ebt_amount = regex_matches[0][0]
-    @cash_amount = regex_matches[1][0]
+    if !invalid_ebt_number?
+      regex_matches = @raw_text.scan(/(\$\S+)/)
+      @ebt_amount = regex_matches[0][0]
+      @cash_amount = regex_matches[1][0]
+    end
+  end
+
+  def invalid_ebt_number?
+    if raw_text.include?("non working card")
+      true
+    else
+      false
+    end
   end
 end

--- a/spec/lib/transcription_spec.rb
+++ b/spec/lib/transcription_spec.rb
@@ -40,4 +40,13 @@ describe Transcription do
       expect(transcription.cash_amount).to eq("$0")
     end
   end
+
+  context 'when the transcription is for an invalid EBT number' do
+    let(:raw_text) { "Our records indicate the number you have entered it's for an non working card in case your number was entered incorrectly please reenter your 16 digit card number followed by the pound sign." }
+    let(:transcription) { Transcription.new(raw_text) }
+
+    it 'is declared invalid' do
+      expect(transcription.invalid_ebt_number?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
... phone line, closes #15 

Tested successfully on staging.

Message currently says:

> I'm sorry, that card number was not found. Please try again. (Note: this service only works in California right now.)

(So it also stays under a single text message character limit.)

Please open an issue if you want to change the copy!
