### PR TITLE
Capture full transcription post sending digits

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -26,14 +26,18 @@ class EbtBalanceSmsApp < Sinatra::Base
     state_abbreviation = params["ToState"] || "no_state_abbreviation_received"
     state_handler = StateHandler.for(state_abbreviation)
     debit_number = state_handler.extract_valid_ebt_number_from_text(params["Body"])
-    twiml_url = "#{settings.url_scheme}://#{request.env['HTTP_HOST']}/get_balance?phone_number=#{texter_phone_number}&twilio_phone_number=#{inbound_twilio_number}&state=#{state_abbreviation}"
+    twiml_url = "#{settings.url_scheme}://"
+    twiml_url << "#{request.env['HTTP_HOST']}/get_balance"
+    twiml_url << "?phone_number=#{texter_phone_number}"
+    twiml_url << "&twilio_phone_number=#{inbound_twilio_number}"
+    twiml_url << "&state=#{state_abbreviation}"
+    twiml_url << "&debit_number=#{debit_number}"
     language = settings.phone_number_processor.language_for(inbound_twilio_number)
     message_generator = MessageGenerator.new(language)
     if debit_number != :invalid_number
       twilio_service.make_call(
         url: twiml_url,
         to: state_handler.phone_number,
-        send_digits: state_handler.button_sequence(debit_number),
         from: inbound_twilio_number,
         method: "GET"
       )
@@ -55,8 +59,12 @@ class EbtBalanceSmsApp < Sinatra::Base
     phone_number = params[:phone_number].strip
     twilio_number = params[:twilio_phone_number].strip
     state = params[:state]
+    state_handler = StateHandler.for(state)
     Twilio::TwiML::Response.new do |r|
-      r.Record :transcribeCallback => "#{settings.url_scheme}://#{request.env['HTTP_HOST']}/#{state}/#{phone_number}/#{twilio_number}/send_balance", :maxLength => 18
+      r.Play digits: state_handler.button_sequence(params['debit_number'])
+      r.Record transcribe: true,
+        transcribeCallback: '/transcribe_callback',
+        maxLength: 18
     end.text
   end
 


### PR DESCRIPTION
Instead of sending the digits, having Twilio make an HTTP request, then telling Twilio to <Record>... move digit sending and <Record> to the same set of TwiML instructions. 
