### PR TITLE
Add 'more info' feature to assuage user concerns, closes #272

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -76,6 +76,12 @@ class EbtBalanceSmsApp < Sinatra::Base
           from: inbound_twilio_number,
           method: "GET"
         )
+      elsif params["Body"].downcase.include?('about')
+        twilio_service.send_text(
+          to: texter_phone_number,
+          from: inbound_twilio_number,
+          body: message_generator.more_info
+        )
       else
         twilio_service.send_text(
           to: texter_phone_number,

--- a/lib/message_generator.rb
+++ b/lib/message_generator.rb
@@ -50,7 +50,7 @@ class MessageGenerator
     if language == :spanish
       'Hola! Usted puede verificar su saldo de EBT por mensaje de texto. Solo responda a este mensaje con su número de tarjeta de EBT.'
     else
-      "Hi there! Reply to this message with your EBT card number and I'll check your balance for you."
+      "Hi there! Reply to this message with your EBT card number and we'll check your balance for you. For more info, text ABOUT."
     end
   end
 
@@ -76,5 +76,9 @@ class MessageGenerator
     else
       'https://s3-us-west-1.amazonaws.com/balance-cfa/balance-voice-splash-v4-012515.mp3'
     end
+  end
+
+  def more_info
+    "This is a free text service provided by non-profit Code for America for checking your EBT balance (standard rates apply). For more info go to www.c4a.me/balance"
   end
 end


### PR DESCRIPTION
- Modifies welcome message sent to users who use the form to say:

> Hi there! Reply to this message with your EBT card number and we'll check your balance for you. For more info, text ABOUT.

- Lets a user text in ABOUT (or about, or About) and receive the following message:

> This is a free text service provided by non-profit Code for America for checking your EBT balance (standard rates apply). For more info go to www.c4a.me/balance

Closes #272 
