### PR TITLE
Fix California timeout issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - "2.1.5"
+  - "2.1.6"
 before_install: gem install foreman
 script: foreman run bundle exec rspec spec
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.1.5'
+ruby '2.1.6'
 
 gem 'sinatra'
 gem 'sinatra-contrib'

--- a/lib/state_handler/ca.rb
+++ b/lib/state_handler/ca.rb
@@ -3,7 +3,7 @@ class StateHandler::CA < StateHandler::Base
   ALLOWED_NUMBER_OF_EBT_CARD_DIGITS = [16]
 
   def button_sequence(ebt_number)
-    "wwww1wwwwww#{ebt_number}ww"
+    "wwww1wwwwww#{ebt_number}#ww"
   end
 
   def transcribe_balance_response(transcription_text, language = :english)

--- a/spec/lib/state_handler_spec.rb
+++ b/spec/lib/state_handler_spec.rb
@@ -113,7 +113,7 @@ describe StateHandler::CA do
   it 'gives correct button sequence' do
     fake_ebt_number = '11112222'
     desired_sequence = subject.button_sequence(fake_ebt_number)
-    expect(desired_sequence).to eq("wwww1wwwwww#{fake_ebt_number}ww")
+    expect(desired_sequence).to eq("wwww1wwwwww#{fake_ebt_number}#ww")
   end
 
   it 'tells the number of digits a CA EBT card has' do


### PR DESCRIPTION
This should fix the sporadic recording timeout issues we've had with California. The PR:

- Adds an explicit pressing of "#" after entering the EBT #
- Bumps the Ruby version to the latest 2.1.x (2.1.6 instead of 2.1.5)
