### PR TITLE
Add half second wait between each digit in CA and pound at end

### DIFF
--- a/lib/state_handler/ca.rb
+++ b/lib/state_handler/ca.rb
@@ -4,7 +4,7 @@ class StateHandler::CA < StateHandler::Base
 
   def button_sequence(ebt_number)
     waiting_ebt_number = ebt_number.split('').join('w')
-    "wwww1wwwwww#{waiting_ebt_number}ww"
+    "wwww1wwwwww#{waiting_ebt_number}w#ww"
   end
 
   def transcribe_balance_response(transcription_text, language = :english)

--- a/lib/state_handler/ca.rb
+++ b/lib/state_handler/ca.rb
@@ -3,7 +3,8 @@ class StateHandler::CA < StateHandler::Base
   ALLOWED_NUMBER_OF_EBT_CARD_DIGITS = [16]
 
   def button_sequence(ebt_number)
-    "wwww1wwwwww#{ebt_number}ww"
+    waiting_ebt_number = ebt_number.split('').join('w')
+    "wwww1wwwwww#{waiting_ebt_number}ww"
   end
 
   def transcribe_balance_response(transcription_text, language = :english)

--- a/spec/lib/state_handler_spec.rb
+++ b/spec/lib/state_handler_spec.rb
@@ -112,9 +112,8 @@ describe StateHandler::CA do
 
   it 'gives correct button sequence' do
     fake_ebt_number = '11112222'
-    waiting_fake_ebt_number = fake_ebt_number.split('').join('w')
     desired_sequence = subject.button_sequence(fake_ebt_number)
-    expect(desired_sequence).to eq("wwww1wwwwww#{waiting_fake_ebt_number}ww")
+    expect(desired_sequence).to eq("wwww1wwwwww1w1w1w1w2w2w2w2ww")
   end
 
   it 'tells the number of digits a CA EBT card has' do

--- a/spec/lib/state_handler_spec.rb
+++ b/spec/lib/state_handler_spec.rb
@@ -110,10 +110,10 @@ describe StateHandler::CA do
     expect(subject.phone_number).to eq('+18773289677')
   end
 
-  it 'gives correct button sequence' do
+  it 'gives correct button sequence (ebt # with pauses between digits and pound at end)' do
     fake_ebt_number = '11112222'
     desired_sequence = subject.button_sequence(fake_ebt_number)
-    expect(desired_sequence).to eq("wwww1wwwwww1w1w1w1w2w2w2w2ww")
+    expect(desired_sequence).to eq("wwww1wwwwww1w1w1w1w2w2w2w2w#ww")
   end
 
   it 'tells the number of digits a CA EBT card has' do

--- a/spec/lib/state_handler_spec.rb
+++ b/spec/lib/state_handler_spec.rb
@@ -112,8 +112,9 @@ describe StateHandler::CA do
 
   it 'gives correct button sequence' do
     fake_ebt_number = '11112222'
+    waiting_fake_ebt_number = fake_ebt_number.split('').join('w')
     desired_sequence = subject.button_sequence(fake_ebt_number)
-    expect(desired_sequence).to eq("wwww1wwwwww#{fake_ebt_number}ww")
+    expect(desired_sequence).to eq("wwww1wwwwww#{waiting_fake_ebt_number}ww")
   end
 
   it 'tells the number of digits a CA EBT card has' do


### PR DESCRIPTION
Have tested a bit, and this seems to reduce the frequency of the IVR recognition error. Thanks to @bsmithgall for the starting commit!