### PR TITLE
Dollar amounts processor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,9 @@ gem 'rack-timeout'
 gem 'newrelic_rpm'
 gem 'activesupport'
 
+# For DollarAmountsProcessor
+gem 'numbers_in_words'
+
 group :test, :development do
   gem 'rspec'
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,8 @@ GEM
     newrelic_rpm (3.14.1.311)
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
+    numbers_in_words (0.4.0)
+      activesupport
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -98,6 +100,7 @@ DEPENDENCIES
   foreman
   newrelic_rpm
   nokogiri
+  numbers_in_words
   pry
   rack-ssl
   rack-test

--- a/lib/dollar_amounts_processor.rb
+++ b/lib/dollar_amounts_processor.rb
@@ -12,7 +12,7 @@ class DollarAmountsProcessor
       amount.gsub!(/cents?/, '')
 
       '$%.2f' % [ NumbersInWords.in_numbers(amount) ]
-    end
+    end.gsub('the euro', '$0.00')
   end
 
 end

--- a/lib/dollar_amounts_processor.rb
+++ b/lib/dollar_amounts_processor.rb
@@ -3,7 +3,7 @@ class DollarAmountsProcessor
 
   Words = NumbersInWords::English.exceptions.values
   MatchWord = /\b(?:#{Words.join('|')})\b/
-  MatchAmount = /(?:#{MatchWord}\s+){1,9}dollars?(?: and)?(?:\s+#{MatchWord}){1,2}\s+cents?/
+  MatchAmount = /(?:#{MatchWord}\s+){1,9}dollars?(?: and)?(?:\s+#{MatchWord}){1,2}\s+cents?/s
 
 
   def process(text_with_words)

--- a/lib/dollar_amounts_processor.rb
+++ b/lib/dollar_amounts_processor.rb
@@ -1,15 +1,21 @@
 require 'numbers_in_words'
 class DollarAmountsProcessor
 
-  Words = NumbersInWords::English.exceptions.values
+  Words = NumbersInWords::English.exceptions.values +
+    NumbersInWords::English.powers_of_ten.values
   MatchWord = /\b(?:#{Words.join('|')})\b/
-  MatchAmount = /(?:#{MatchWord}\s+){1,9}dollars?(?: and)?(?:\s+#{MatchWord}){1,2}\s+cents?/s
+  MatchAmount = /(?:#{MatchWord}\s+){1,9}dollars?/s
+  MatchAmountWithCent = /#{MatchAmount}(?: and)?(?:\s+#{MatchWord}){1,2}\s+cents?/s
 
 
   def process(text_with_words)
-    text_with_words.gsub(MatchAmount) do |amount|
+    text_with_words.gsub(MatchAmountWithCent) do |amount|
       amount.gsub!(/dollars?/, 'point')
       amount.gsub!(/cents?/, '')
+
+      '$%.2f' % [ NumbersInWords.in_numbers(amount) ]
+    end.gsub(MatchAmount) do |amount|
+      amount.gsub!(/dollars?/, '')
 
       '$%.2f' % [ NumbersInWords.in_numbers(amount) ]
     end.gsub('the euro', '$0.00')

--- a/lib/dollar_amounts_processor.rb
+++ b/lib/dollar_amounts_processor.rb
@@ -1,3 +1,7 @@
 class DollarAmountsProcessor
 
+  def process(text_with_words)
+    text_with_words
+  end
+
 end

--- a/lib/dollar_amounts_processor.rb
+++ b/lib/dollar_amounts_processor.rb
@@ -1,0 +1,3 @@
+class DollarAmountsProcessor
+
+end

--- a/lib/dollar_amounts_processor.rb
+++ b/lib/dollar_amounts_processor.rb
@@ -1,7 +1,18 @@
+require 'numbers_in_words'
 class DollarAmountsProcessor
 
+  Words = NumbersInWords::English.exceptions.values
+  MatchWord = /\b(?:#{Words.join('|')})\b/
+  MatchAmount = /(?:#{MatchWord}\s+){1,9}dollars?(?: and)?(?:\s+#{MatchWord}){1,2}\s+cents?/
+
+
   def process(text_with_words)
-    text_with_words
+    text_with_words.gsub(MatchAmount) do |amount|
+      amount.gsub!(/dollars?/, 'point')
+      amount.gsub!(/cents?/, '')
+
+      '$%.2f' % [ NumbersInWords.in_numbers(amount) ]
+    end
   end
 
 end

--- a/spec/dollar_amounts_processor_spec_helper.rb
+++ b/spec/dollar_amounts_processor_spec_helper.rb
@@ -1,0 +1,3 @@
+require File.expand_path('../spec_helper', __FILE__)
+require File.expand_path('../../lib/dollar_amounts_processor', __FILE__)
+

--- a/spec/dollar_amounts_processor_spec_helper.rb
+++ b/spec/dollar_amounts_processor_spec_helper.rb
@@ -1,3 +1,25 @@
 require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../../lib/dollar_amounts_processor', __FILE__)
 
+RSpec::Matchers.define :eq_text do |expected|
+  def compr(text)
+    text.gsub(/[\s\n\r]+/s,' ')
+  end
+  match do |actual|
+    @expected = compr(expected)
+    @actual   = compr(actual)
+    @expected == @actual
+  end
+  failure_message do
+    "\nexpected: #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using ==)\n"
+  end
+
+  def expected_formatted
+    RSpec::Support::ObjectFormatter.format(@expected)
+  end
+
+  # @private
+  def actual_formatted
+    RSpec::Support::ObjectFormatter.format(@actual)
+  end
+end

--- a/spec/lib/dollar_amounts_processor_spec.rb
+++ b/spec/lib/dollar_amounts_processor_spec.rb
@@ -10,7 +10,7 @@ describe DollarAmountsProcessor do
         receipt from your last purchase and or your last cash purchase or cashback
         Prinz action. You will always have your.
       EOIN
-      )).to eq <<-EOOUT
+      )).to eq_text <<-EOOUT
         Your food stamp balance is $6.25. Your cash account
         balance is $11.69. As a reminder. By saving the
         receipt from your last purchase and or your last cash purchase or cashback
@@ -25,7 +25,7 @@ describe DollarAmountsProcessor do
         know your current balance. Remember you can also access your account
         information online at.
       EOIN
-      )).to eq <<-EOOUT
+      )).to eq_text <<-EOOUT
         Your snap balance is $426.00. Your cash balance is $0.00.
         As a reminder by saving the receipt from your last purchase you will
         know your current balance. Remember you can also access your account
@@ -39,7 +39,7 @@ describe DollarAmountsProcessor do
         balance is seven hundred sixty six dollars and thirty seven cents. You are
         eligible to enroll in a free service called my own.
       EOIN
-      )).to eq <<-EOOUT
+      )).to eq_text <<-EOOUT
         One moment please. OK. I've pulled up your account information. Your food stamp
         balance is $766.37. You are
         eligible to enroll in a free service called my own.
@@ -52,7 +52,7 @@ describe DollarAmountsProcessor do
         balance is seven hundred sixty six dollars and thirty seven cents. You are
         eligible to enroll in a free service called my alerts.
       EOIN
-      )).to eq <<-EOOUT
+      )).to eq_text <<-EOOUT
         One moment please. OK. I've pulled up your account information. Your food stamp
         balance is $766.37. You are
         eligible to enroll in a free service called my alerts.
@@ -66,7 +66,7 @@ describe DollarAmountsProcessor do
         receipt from your last purchase and or your last cash purchase or cashback
         transaction. You will always have you.
       EOIN
-      )).to eq <<-EOOUT
+      )).to eq_text <<-EOOUT
         Balance is one $171.86. Your cash
         account balance is $0.90. As a reminder. By saving the
         receipt from your last purchase and or your last cash purchase or cashback
@@ -81,7 +81,7 @@ describe DollarAmountsProcessor do
         receipt from your last purchase and or your last cash purchase or cashback
         transaction. You will always have your current.
       EOIN
-      )).to eq <<-EOOUT
+      )).to eq_text <<-EOOUT
         Balance is $501.23. Your cash account
         balance is $2.51. As a reminder. By saving the
         receipt from your last purchase and or your last cash purchase or cashback
@@ -96,7 +96,7 @@ describe DollarAmountsProcessor do
         know your current balance. Remember you can also access your account
         information online at W W.
       EOIN
-      )).to eq <<-EOOUT
+      )).to eq_text <<-EOOUT
         Snap balance is $314.00. Your cash balance is $0.00.
         As a reminder by saving the receipt from your last purchase you'll
         know your current balance. Remember you can also access your account
@@ -111,7 +111,7 @@ describe DollarAmountsProcessor do
         your last cash purchase or cashback transaction.  You will always have your
         current balance. Some A.T.M.'s will also print your balance on a cash with the.
       EOIN
-      )).to eq <<-EOOUT
+      )).to eq_text <<-EOOUT
         Balance is $0.00. Dollars. Your cash account balance is $541.00
         as a reminder. By saving the receipt from your last purchase and or
         your last cash purchase or cashback transaction.  You will always have your

--- a/spec/lib/dollar_amounts_processor_spec.rb
+++ b/spec/lib/dollar_amounts_processor_spec.rb
@@ -1,0 +1,5 @@
+require File.expand_path('../../dollar_amounts_processor_spec_helper', __FILE__)
+
+describe DollarAmountsProcessor do
+
+end

--- a/spec/lib/dollar_amounts_processor_spec.rb
+++ b/spec/lib/dollar_amounts_processor_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../dollar_amounts_processor_spec_helper', __FILE__)
 describe DollarAmountsProcessor do
 
   describe "requested test data" do
-    it "replaces words with numbers" do
+    it "replaces words with numbers in sample text #01" do
       expect(subject.process(<<-EOIN
         Your food stamp balance is six dollars and twenty five cents. Your cash account
         balance is eleven dollars and sixty nine cents. As a reminder. By saving the
@@ -17,6 +17,106 @@ describe DollarAmountsProcessor do
         Prinz action. You will always have your.
       EOOUT
     end
-  end
 
+    it "replaces words with numbers in sample text #02" do
+      expect(subject.process(<<-EOIN
+        Your snap balance is four hundred twenty six dollars. Your cash balance is zero
+        dollars. As a reminder by saving the receipt from your last purchase you will
+        know your current balance. Remember you can also access your account
+        information online at.
+      EOIN
+      )).to eq <<-EOOUT
+        Your snap balance is $426.00. Your cash balance is $0.00.
+        As a reminder by saving the receipt from your last purchase you will
+        know your current balance. Remember you can also access your account
+        information online at.
+      EOOUT
+    end
+
+    it "replaces words with numbers in sample text #03" do
+      expect(subject.process(<<-EOIN
+        One moment please. OK. I've pulled up your account information. Your food stamp
+        balance is seven hundred sixty six dollars and thirty seven cents. You are
+        eligible to enroll in a free service called my own.
+      EOIN
+      )).to eq <<-EOOUT
+        One moment please. OK. I've pulled up your account information. Your food stamp
+        balance is $766.37. You are
+        eligible to enroll in a free service called my own.
+      EOOUT
+    end
+
+    it "replaces words with numbers in sample text #04" do
+      expect(subject.process(<<-EOIN
+        One moment please. OK. I've pulled up your account information. Your food stamp
+        balance is seven hundred sixty six dollars and thirty seven cents. You are
+        eligible to enroll in a free service called my alerts.
+      EOIN
+      )).to eq <<-EOOUT
+        One moment please. OK. I've pulled up your account information. Your food stamp
+        balance is $766.37. You are
+        eligible to enroll in a free service called my alerts.
+      EOOUT
+    end
+
+    it "replaces words with numbers in sample text #05" do
+      expect(subject.process(<<-EOIN
+        Balance is one hundred seventy one dollars and sixty eight cents. Your cash
+        account balance is zero dollars and ninety cents. As a reminder. By saving the
+        receipt from your last purchase and or your last cash purchase or cashback
+        transaction. You will always have you.
+      EOIN
+      )).to eq <<-EOOUT
+        Balance is one $171.86. Your cash
+        account balance is $0.90. As a reminder. By saving the
+        receipt from your last purchase and or your last cash purchase or cashback
+        transaction. You will always have you.
+      EOOUT
+    end
+
+    it "replaces words with numbers in sample text #06" do
+      expect(subject.process(<<-EOIN
+        Balance is four hundred one dollars and twenty three cents. Your cash account
+        balance is two dollars and fifty one cents. As a reminder. By saving the
+        receipt from your last purchase and or your last cash purchase or cashback
+        transaction. You will always have your current.
+      EOIN
+      )).to eq <<-EOOUT
+        Balance is $501.23. Your cash account
+        balance is $2.51. As a reminder. By saving the
+        receipt from your last purchase and or your last cash purchase or cashback
+        transaction. You will always have your current.
+      EOOUT
+    end
+
+    it "replaces words with numbers in sample text #07" do
+      expect(subject.process(<<-EOIN
+        Snap balance is three hundred fourteen dollars. Your cash balance is zero
+        dollars. As a reminder by saving the receipt from your last purchase you'll
+        know your current balance. Remember you can also access your account
+        information online at W W.
+      EOIN
+      )).to eq <<-EOOUT
+        Snap balance is $314.00. Your cash balance is $0.00.
+        As a reminder by saving the receipt from your last purchase you'll
+        know your current balance. Remember you can also access your account
+        information online at W W.
+      EOOUT
+    end
+
+    it "replaces words with numbers in sample text #08 (bonus ;)" do
+      expect(subject.process(<<-EOIN
+        Balance is the euro. Dollars. Your cash account balance is five hundred forty
+        one dollars as a reminder. By saving the receipt from your last purchase and or
+        your last cash purchase or cashback transaction.  You will always have your
+        current balance. Some A.T.M.'s will also print your balance on a cash with the.
+      EOIN
+      )).to eq <<-EOOUT
+        Balance is $0.00. Dollars. Your cash account balance is $541.00
+        as a reminder. By saving the receipt from your last purchase and or
+        your last cash purchase or cashback transaction.  You will always have your
+        current balance. Some A.T.M.'s will also print your balance on a cash with the.
+      EOOUT
+    end
+  end
 end

--- a/spec/lib/dollar_amounts_processor_spec.rb
+++ b/spec/lib/dollar_amounts_processor_spec.rb
@@ -67,7 +67,7 @@ describe DollarAmountsProcessor do
         transaction. You will always have you.
       EOIN
       )).to eq_text <<-EOOUT
-        Balance is one $171.86. Your cash
+        Balance is $171.68. Your cash
         account balance is $0.90. As a reminder. By saving the
         receipt from your last purchase and or your last cash purchase or cashback
         transaction. You will always have you.
@@ -82,7 +82,7 @@ describe DollarAmountsProcessor do
         transaction. You will always have your current.
       EOIN
       )).to eq_text <<-EOOUT
-        Balance is $501.23. Your cash account
+        Balance is $401.23. Your cash account
         balance is $2.51. As a reminder. By saving the
         receipt from your last purchase and or your last cash purchase or cashback
         transaction. You will always have your current.

--- a/spec/lib/dollar_amounts_processor_spec.rb
+++ b/spec/lib/dollar_amounts_processor_spec.rb
@@ -2,4 +2,21 @@ require File.expand_path('../../dollar_amounts_processor_spec_helper', __FILE__)
 
 describe DollarAmountsProcessor do
 
+  describe "requested test data" do
+    it "replaces words with numbers" do
+      expect(subject.process(<<-EOIN
+        Your food stamp balance is six dollars and twenty five cents. Your cash account
+        balance is eleven dollars and sixty nine cents. As a reminder. By saving the
+        receipt from your last purchase and or your last cash purchase or cashback
+        Prinz action. You will always have your.
+      EOIN
+      )).to eq <<-EOOUT
+        Your food stamp balance is $6.25. Your cash account
+        balance is $11.69. As a reminder. By saving the
+        receipt from your last purchase and or your last cash purchase or cashback
+        Prinz action. You will always have your.
+      EOOUT
+    end
+  end
+
 end


### PR DESCRIPTION
A quick test-driven implementation of the English language dollar amount parsing requested in #343 as a service object, so you can put in into your pipeline anywhere.

Might eat newlines included in numbers, but I guess that's expected.