### PR TITLE
Using standard Ruby `i18n` library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'unicorn'
 gem 'rack-timeout'
 gem 'newrelic_rpm'
 gem 'activesupport'
+gem 'sinatra-i18n'
 
 # For DollarAmountsProcessor
 gem 'numbers_in_words'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
+    sinatra-i18n (0.1.0)
     slop (3.6.0)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -109,11 +110,15 @@ DEPENDENCIES
   rspec
   sinatra
   sinatra-contrib
+  sinatra-i18n
   timecop
   twilio-ruby
   unicorn
   vcr
   webmock
 
+RUBY VERSION
+   ruby 2.2.4p230
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,8 @@ require 'sinatra/json'
 require 'twilio-ruby'
 require 'rack/ssl'
 require 'active_support/core_ext/time'
+require 'sinatra/i18n'
+require 'i18n/backend/fallbacks'
 require File.expand_path('../lib/twilio_service', __FILE__)
 require File.expand_path('../lib/state_handler', __FILE__)
 require File.expand_path('../lib/phone_number_processor', __FILE__)
@@ -17,6 +19,15 @@ class EbtBalanceSmsApp < Sinatra::Base
     set :url_scheme, 'http'
   end
   set :phone_number_processor, PhoneNumberProcessor.new
+
+  configure do
+    I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+    set :locales, Dir[
+      File.join(settings.root, 'config', 'locales', '*.yml'),
+      File.join(settings.root, 'config', 'locales', '*.rb')
+    ]
+    register Sinatra::I18n
+  end
 
   configure :production do
     require 'newrelic_rpm'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,13 @@
+en:
+  welcome: "Hi there! Reply to this message with your EBT card number and we'll check your balance for you. For more info, text ABOUT."
+  thanks_please_wait: "Thanks! Please wait 1-2 minutes while we check your balance."
+  having_trouble_try_again_message: "I'm sorry! We're having trouble contacting the EBT system right now. Please try again in a few minutes or call this # and press 1 to use the state phone system."
+  card_number_not_found_message: "I'm sorry, that card number was not found. Please try again."
+  more_info: "This is a free text service by non-profit Code for America for checking your EBT balance (standard msg rates apply). For more info go to http://c4a.me/balance"
+  balance_message:
+    default: "Hi! Your food stamp balance is %{balance}."
+    optional: "Hi! Your food stamp balance is %{balance} and your cash balance is %{cash}."
+  sorry_try_again:
+    default: "Sorry! That number doesn't look right. Please reply with your EBT card number or ABOUT for more information."
+    one_number: "Sorry! That number doesn't look right. Please reply with your %{digits_one}-digit EBT card number or ABOUT for more information."
+    two_numbers: "Sorry! That number doesn't look right. Please reply with your %{digits_one}- or %{digits_two}-digit EBT card number or ABOUT for more information."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,10 @@
+es:
+  welcome: "Hola! Usted puede verificar su saldo de EBT por mensaje de texto. Solo responda a este mensaje con su número de tarjeta de EBT."
+  thanks_please_wait: "Gracias! Favor de esperar 1-2 minutos mientras verificamos su saldo de EBT."
+  having_trouble_try_again_message: "Lo siento! Actualmente estamos teniendo problemas comunicándonos con el sistema de EBT. Favor de enviar su # de EBT por texto en unos minutos."
+  card_number_not_found_message: "Lo siento, no se encontró el número de tarjeta. Por favor, inténtelo de nuevo."
+  balance_message:
+    default: "Hola! El saldo de su cuenta de estampillas para comida es %{balance}."
+    optional: "Hola! El saldo de su cuenta de estampillas para comida es %{balance} y su balance de dinero en efectivo es %{cash}."
+  sorry_try_again:
+    default: "Perdon, ese número de EBT no esta trabajando. Favor de intentarlo otra vez."

--- a/lib/message_generator.rb
+++ b/lib/message_generator.rb
@@ -3,71 +3,48 @@ class MessageGenerator
 
   def initialize(language = :english)
     @language = language
+    case @language
+    when :spanish
+      I18n.locale = :es
+    else
+      I18n.locale = :en
+    end
   end
 
   def thanks_please_wait
-    if language == :spanish
-      "Gracias! Favor de esperar 1-2 minutos mientras verificamos su saldo de EBT."
-    else
-      "Thanks! Please wait 1-2 minutes while we check your balance."
-    end
+    I18n.t :thanks_please_wait
   end
 
   def balance_message(food_stamp_balance, optional_balances = {})
-    if language == :spanish
-      if optional_balances[:cash]
-        balance_message = "Hola! El saldo de su cuenta de estampillas para comida es #{food_stamp_balance} y su balance de dinero en efectivo es #{optional_balances[:cash]}."
-      else
-        balance_message = "Hola! El saldo de su cuenta de estampillas para comida es #{food_stamp_balance}."
-      end
+    if optional_balances[:cash]
+      I18n.t :optional, scope: [:balance_message], balance: food_stamp_balance, cash: optional_balances[:cash]
     else
-      if optional_balances[:cash]
-        balance_message = "Hi! Your food stamp balance is #{food_stamp_balance} and your cash balance is #{optional_balances[:cash]}."
-      else
-        balance_message = "Hi! Your food stamp balance is #{food_stamp_balance}."
-      end
+      I18n.t :default, scope: [:balance_message], balance: food_stamp_balance
     end
-    balance_message
   end
 
   def sorry_try_again(digits_array = [])
-    if language == :spanish
-      "Perdon, ese número de EBT no esta trabajando. Favor de intentarlo otra vez."
+    if digits_array == nil
+      I18n.t :default, scope: [:sorry_try_again]
+    elsif digits_array.length == 1
+      I18n.t :one_number, scope: [:sorry_try_again], default: [:default], digits_one: digits_array[0]
+    elsif digits_array.length == 2
+      I18n.t :two_numbers, scope: [:sorry_try_again], default: [:default], digits_one: digits_array[0], digits_two: digits_array[1]
     else
-      if digits_array == nil
-        "Sorry! That number doesn't look right. Please reply with your EBT card number or ABOUT for more information."
-      elsif digits_array.length == 1
-        "Sorry! That number doesn't look right. Please reply with your #{digits_array[0]}-digit EBT card number or ABOUT for more information."
-      elsif digits_array.length == 2
-        "Sorry! That number doesn't look right. Please reply with your #{digits_array[0]}- or #{digits_array[1]}-digit EBT card number or ABOUT for more information."
-      else
-        "Sorry! That number doesn't look right. Please reply with your EBT card number or ABOUT for more information."
-      end
+      I18n.t :default, scope: [:sorry_try_again]
     end
   end
 
   def welcome
-    if language == :spanish
-      'Hola! Usted puede verificar su saldo de EBT por mensaje de texto. Solo responda a este mensaje con su número de tarjeta de EBT.'
-    else
-      "Hi there! Reply to this message with your EBT card number and we'll check your balance for you. For more info, text ABOUT."
-    end
+    I18n.t :welcome
   end
 
   def having_trouble_try_again_message
-    if language == :spanish
-      "Lo siento! Actualmente estamos teniendo problemas comunicándonos con el sistema de EBT. Favor de enviar su # de EBT por texto en unos minutos."
-    else
-      "I'm sorry! We're having trouble contacting the EBT system right now. Please try again in a few minutes or call this # and press 1 to use the state phone system."
-    end
+    I18n.t :having_trouble_try_again_message
   end
 
   def card_number_not_found_message
-    if language == :spanish
-      "Lo siento, no se encontró el número de tarjeta. Por favor, inténtelo de nuevo."
-    else
-      "I'm sorry, that card number was not found. Please try again."
-    end
+    I18n.t :card_number_not_found_message
   end
 
   def call_in_voice_file_url
@@ -79,6 +56,6 @@ class MessageGenerator
   end
 
   def more_info
-    "This is a free text service by non-profit Code for America for checking your EBT balance (standard msg rates apply). For more info go to http://c4a.me/balance"
+    I18n.t :more_info
   end
 end

--- a/spec/app_spec_helper.rb
+++ b/spec/app_spec_helper.rb
@@ -2,12 +2,22 @@ require 'spec_helper'
 require 'rack/test'
 require 'nokogiri'
 require 'sinatra'
+require 'sinatra/i18n'
+require 'i18n/backend/fallbacks'
 require 'vcr'
 require 'timecop'
 require File.expand_path('../rack_spec_helpers', __FILE__)
 
 class EbtBalanceSmsApp < Sinatra::Base
   set :environment, :test
+  configure do
+    I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+    set :locales, Dir[
+      File.join(settings.root, '..', 'config', 'locales', '*.yml'),
+      File.join(settings.root, '..', 'config', 'locales', '*.rb')
+    ]
+    register Sinatra::I18n
+  end
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
During today’s National Day of Civic Hacking in Charlotte, Jim van Fleet showed off the NC Balance project. He got a question about how it works with different languages, and we looked at the code to understand it and noticed the somewhat primitive `if`/`else` clauses in the message generator. We figured that we could make this better by using the Ruby `i18n` package instead.

This change does not change the messages in any way other than using `I18n.t to` translate them with. New languages can easily be added by adding a new case statement to the language assignment in `MessageGenerator.initialize` as well as a file in `config/locales`.

Added support for internationalization to alleviate if/else bloat.
Loading locales into Sinatra on initialization.
Updated specs to work with `i18n` and `sinatra/i18n`.
Updated `message_generator.rb` with `I18n.t` usage.

